### PR TITLE
Added serializers for bikes/stock

### DIFF
--- a/bikes/serializers.py
+++ b/bikes/serializers.py
@@ -29,6 +29,12 @@ class BikeStockSerializer(serializers.ModelSerializer):
         ]
 
 
+class BikeModelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Bike
+        fields = "__all__"
+
+
 class BikeSerializer(serializers.ModelSerializer):
     type = serializers.StringRelatedField(source="type.name")
     brand = serializers.StringRelatedField(source="brand.name")

--- a/bikes/urls.py
+++ b/bikes/urls.py
@@ -9,5 +9,7 @@ urlpatterns = [
     path("stock", views.BikeStockListView.as_view()),
     path("stock/<int:pk>/", views.BikeStockDetailView.as_view()),
     path("rental/", views.RentalListView.as_view()),
-    path("rental/<int:pk>/", views.RentalDetailView.as_view())
+    path("rental/<int:pk>/", views.RentalDetailView.as_view()),
+    path("models/", views.BikeModelListView.as_view()),
+    path("models/<int:pk>/", views.BikeModelDetailView.as_view()),
 ]

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -14,7 +14,18 @@ from bikes.serializers import (
     BikeSerializer,
     BikeStockListSerializer,
     BikeStockDetailSerializer,
+    BikeModelSerializer,
 )
+
+
+class BikeModelListView(generics.ListCreateAPIView):
+    queryset = Bike.objects.all()
+    serializer_class = BikeModelSerializer
+
+
+class BikeModelDetailView(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Bike.objects.all()
+    serializer_class = BikeModelSerializer
 
 
 class BikeStockListView(generics.ListAPIView):


### PR DESCRIPTION
**Description**

- Removed depth from bikes/stock serializers.
- Created several serializers to replace depth nesting
- test this by going to http://localhost:8000/bikes/stock . For each bikestock bike should show type, brand etc and their fields. For individual bike stock detail (for example http://localhost:8000/bikes/stock/1/) you should also see additional fields for storage.
- Added views, urls, and serializer for bike bikes, using name bikemodel for and pending further renaming for model Bike under bikes. http://localhost:8000/bikes/models/ and with pk for individual view

Example:
[Trello #383](https://trello.com/c/onk00Rfy)