### PR TITLE
519-back-tilauksen-poisto-palauttaa-tuotteet-uudelleen-tilattaviksi

### DIFF
--- a/orders/views.py
+++ b/orders/views.py
@@ -291,6 +291,10 @@ class OrderDetailView(RetrieveUpdateDestroyAPIView):
 
     def destroy(self, request, *args, **kwargs):
         order = self.get_object()
+        if order.status == "Finished":
+            return Response(
+                "Cant delete finished orders", status=status.HTTP_403_FORBIDDEN
+            )
         log_entry = ProductItemLogEntry.objects.create(
             action=ProductItemLogEntry.ActionChoices.ORDER_REMOVE, user=request.user
         )


### PR DESCRIPTION
**Description**

Order destroy method now returns all ProductItems linked to Order instance back to circulation by turning available field to True.
Order destroy also creates LogEntry instance that will be linked to all of the ProductItems linked to that Order.
Added check that you cant delete Order instance if its status is "Finished".

**Trello card**

[Trello Card #519](519-back-tilauksen-poisto-palauttaa-tuotteet-uudelleen-tilattaviksi)
