### PR TITLE
582 back varasto oikeudet fix

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -602,7 +602,7 @@ class StorageListView(generics.ListCreateAPIView):
 
     permission_classes = [IsAuthenticated, HasGroupPermission]
     required_groups = {
-        "GET": ["admin_group", "user_group"],
+        "GET": ["storage_group", "user_group"],
         "POST": ["admin_group", "user_group"],
     }
 


### PR DESCRIPTION
**Description**

- Changed StorageListView required_groups to require storage_group, Manipulating products with storage_group permissions                                      should now work properly.

**Trello card**

[Trello #582](https://trello.com/c/GWfCtVV4)