### PR TITLE
Bike ordering bugfix

### DIFF
--- a/bikes/serializers.py
+++ b/bikes/serializers.py
@@ -391,6 +391,7 @@ class BikeAvailabilityListSerializer(serializers.ModelSerializer):
         model = BikeStock
         fields = [
             "id",
+            "bike_id",
             "rental",
         ]
 

--- a/bikes/serializers.py
+++ b/bikes/serializers.py
@@ -1,3 +1,6 @@
+import datetime
+from django.utils import timezone
+
 from rest_framework import serializers
 
 from products.serializers import (
@@ -24,6 +27,20 @@ from .models import (
 class BikeRentalSerializer(serializers.ModelSerializer):
     class Meta:
         model = BikeRental
+        fields = "__all__"
+
+
+# allows filtering bike rentals by start date, so that we don't show year old rentals in bike availability endpoint
+class BikeRentalDateSerializer(serializers.ListSerializer):
+    def to_representation(self, data):
+        data = data.filter(start_date__gte=timezone.now() - datetime.timedelta(days=30))
+        return super(BikeRentalDateSerializer, self).to_representation(data)
+
+
+class BikeRentalFilteredSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = BikeRental
+        list_serializer_class = BikeRentalDateSerializer
         fields = "__all__"
 
 
@@ -385,7 +402,9 @@ class BikePackageCreateResponseSerializer(serializers.ModelSerializer):
 
 
 class BikeAvailabilityListSerializer(serializers.ModelSerializer):
-    rental = BikeRentalSerializer(many=True)
+    rental = BikeRentalFilteredSerializer(
+        many=True,
+    )
 
     class Meta:
         model = BikeStock

--- a/bikes/serializers.py
+++ b/bikes/serializers.py
@@ -72,7 +72,7 @@ class BikeRentalSchemaResponseSerializer(serializers.ModelSerializer):
 
 
 class BikeStockSerializer(serializers.ModelSerializer):
-    rental = BikeRentalSerializer(many=True)
+    rental = BikeRentalFilteredSerializer(many=True)
 
     class Meta:
         model = BikeStock
@@ -402,7 +402,7 @@ class BikePackageCreateResponseSerializer(serializers.ModelSerializer):
 
 
 class BikeAvailabilityListSerializer(serializers.ModelSerializer):
-    rental = BikeRentalFilteredSerializer(
+    rental = BikeRentalSerializer(
         many=True,
     )
 

--- a/bikes/urls.py
+++ b/bikes/urls.py
@@ -1,4 +1,5 @@
 """Url paths of the bike rental app."""
+
 from django.urls import path
 
 from . import views
@@ -6,6 +7,7 @@ from . import views
 app_name = "bikes"
 urlpatterns = [
     path("", views.MainBikeList.as_view()),
+    path("availability/", views.BikeAvailability.as_view()),
     path("stock/", views.BikeStockListView.as_view()),
     path("stock/<int:pk>/", views.BikeStockDetailView.as_view()),
     path("rental/", views.RentalListView.as_view()),

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -512,7 +512,10 @@ class RentalListView(generics.ListCreateAPIView):
             return Response(postserializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         bikerentalserializer = BikeAvailabilityListSerializer(
-            BikeStock.objects.all(), many=True
+            BikeStock.objects.filter(
+                bike_id__in=list(request.data["bike_stock"].keys())
+            ),
+            many=True,
         )
         trailer_rental_serializer = BikeTrailerAvailabilityListSerializer(
             BikeTrailer.objects.all(), many=True
@@ -537,14 +540,11 @@ class RentalListView(generics.ListCreateAPIView):
                 date = start_date
                 while date <= end_date:
                     date_str = date.strftime("%d.%m.%Y")
-                    if (
-                        date_str not in bike["rental_dates"]
-                        and date > timezone.now() - datetime.timedelta(days=10)
-                        and date <= end_date - datetime.timedelta(days=10)
-                    ):
+                    if date_str not in bike["rental_dates"]:
                         bike["rental_dates"].append(date_str)
                     date += datetime.timedelta(days=1)
             del bike["rental"]
+
         unavailable_dates = {}
         for bikedata in bikerentalserializer.data:
             unavailable_dates[bikedata["id"]] = bikedata["rental_dates"]
@@ -621,6 +621,8 @@ class RentalListView(generics.ListCreateAPIView):
                                 in unavailable_dates[bike_id.id]
                             ):
                                 available_bikes = available_bikes.exclude(id=bike_id.id)
+                                break
+
                             check_date += datetime.timedelta(days=1)
                 amount = request.data["bike_stock"][rental_item]
                 for bike in range(amount):

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -676,8 +676,8 @@ class RentalListView(generics.ListCreateAPIView):
             BikeTrailer.objects.all(), many=True
         )
         end_date_with_maintenance = request_end_date
-        _, end_date_with_maintenance = add_maintananse_dates(
-            None, end_date_with_maintenance.isoformat()
+        end_date_with_maintenance = add_maintananse_dates(
+            end_date_with_maintenance.isoformat()
         )
 
         for bike in bikerentalserializer.data:

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -305,142 +305,11 @@ class MainBikeList(generics.ListAPIView):
         available_from = today + datetime.timedelta(days=7)
         available_to = today + datetime.timedelta(days=183)
         fin_holidays = holidays.FI()
-
-        bike_serializer = BikeSerializer(Bike.objects.all(), many=True)
         bike_type_serializer = BikeTypeSerializer(BikeType.objects.all(), many=True)
-        bike_package_serializer = BikePackageSerializer(
-            BikePackage.objects.all(), many=True
-        )
+
         trailer_serializer = BikeTrailerMainSerializer(
             BikeTrailerModel.objects.all(), many=True
         )
-
-        for index, bike_model in enumerate(bike_serializer.data):
-            package_only_count = 0
-            unavailable = {}
-            package_only_unavailable = {}
-            for bike in bike_model["stock"]:
-                bike["rental_dates"] = []
-                if bike["package_only"] is True:
-                    package_only_count += 1
-                    for rental in bike["rental"]:
-                        start_date = datetime.datetime.fromisoformat(
-                            rental["start_date"]
-                        )
-                        end_date = datetime.datetime.fromisoformat(rental["end_date"])
-                        # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
-                        end_date += datetime.timedelta(days=1)
-                        while end_date.weekday() >= 5 or end_date in fin_holidays:
-                            end_date += datetime.timedelta(days=1)
-                        second_day = end_date + datetime.timedelta(days=1)
-                        if second_day.weekday() >= 5 or second_day in fin_holidays:
-                            while (
-                                second_day.weekday() >= 5 or second_day in fin_holidays
-                            ):
-                                end_date += datetime.timedelta(days=1)
-                                second_day += datetime.timedelta(days=1)
-                            end_date += datetime.timedelta(days=1)
-                        else:
-                            end_date += datetime.timedelta(days=1)
-                        date = start_date
-                        while date <= end_date:
-                            # consider filter range if provided
-                            current_date = (
-                                date.date()
-                                if isinstance(date, datetime.datetime)
-                                else date
-                            )
-                            date_str = date.strftime("%d.%m.%Y")
-                            if date_str in package_only_unavailable:
-                                package_only_unavailable[date_str] = (
-                                    1 + package_only_unavailable[date_str]
-                                )
-                            else:
-                                package_only_unavailable[date_str] = 1
-                            date += datetime.timedelta(days=1)
-                else:
-                    for rental in bike["rental"]:
-                        start_date = datetime.datetime.fromisoformat(
-                            rental["start_date"]
-                        )
-                        end_date = datetime.datetime.fromisoformat(rental["end_date"])
-                        # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
-                        end_date += datetime.timedelta(days=1)
-                        while end_date.weekday() >= 5 or end_date in fin_holidays:
-                            end_date += datetime.timedelta(days=1)
-                        second_day = end_date + datetime.timedelta(days=1)
-                        if second_day.weekday() >= 5 or second_day in fin_holidays:
-                            while (
-                                second_day.weekday() >= 5 or second_day in fin_holidays
-                            ):
-                                end_date += datetime.timedelta(days=1)
-                                second_day += datetime.timedelta(days=1)
-                            end_date += datetime.timedelta(days=1)
-                        else:
-                            end_date += datetime.timedelta(days=1)
-                        date = start_date
-                        while date <= end_date:
-                            # consider filter range if provided
-                            current_date = (
-                                date.date()
-                                if isinstance(date, datetime.datetime)
-                                else date
-                            )
-                            date_str = date.strftime("%d.%m.%Y")
-                            # if date_str not in bike["rental_dates"]:
-                            #    bike["rental_dates"].append(date_str)
-                            if date_str in unavailable:
-
-                                unavailable[date_str] = 1 + unavailable[date_str]
-                            else:
-                                unavailable[date_str] = 1
-                            date += datetime.timedelta(days=1)
-
-                del bike["rental"]
-
-            bike_serializer.data[index]["unavailable"] = unavailable
-            bike_serializer.data[index]["package_only_count"] = package_only_count
-            bike_serializer.data[index][
-                "package_only_unavailable"
-            ] = package_only_unavailable
-            # del bike_serializer.data[index]["stock"]
-
-        for index, package in enumerate(bike_package_serializer.data):
-            serializer_package = bike_package_serializer.data[index]
-            serializer_package["type"] = "Paketti"
-            serializer_package["unavailable"] = {}
-            serializer_package["brand"] = None
-            serializer_package["color"] = None
-            max_available = None
-            for bike in package["bikes"]:
-                bike_object = Bike.objects.get(id=bike["bike"])
-                if "size" in serializer_package:
-                    serializer_package["size"] = (
-                        f"{serializer_package['size']} & {bike_object.size.name}"
-                    )
-                else:
-                    serializer_package["size"] = bike_object.size.name
-                bike_object_serializer = BikeSerializer(bike_object)
-                if "picture" in serializer_package:
-                    serializer_package["picture"] = (
-                        f"{serializer_package['picture']}&{bike_object.picture.picture_address}"
-                    )
-                else:
-                    serializer_package["picture"] = (
-                        f"{bike_object.picture.picture_address}"
-                    )
-                if bike["amount"] == 0:
-                    bike_max_available = bike["amount"]
-                else:
-                    bike_max_available = math.floor(
-                        bike_object_serializer.data["max_available"] / bike["amount"]
-                    )
-                if max_available is None:
-                    max_available = bike_max_available
-                else:
-                    max_available = min(max_available, bike_max_available)
-            serializer_package["max_available"] = max_available
-
         for index, trailer in enumerate(trailer_serializer.data):
             unavailable = {}
             for trailer in trailer["trailer"]:
@@ -480,8 +349,6 @@ class MainBikeList(generics.ListAPIView):
                     "available_from": available_from,
                     "available_to": available_to,
                 },
-                "bikes": bike_serializer.data,
-                "packages": bike_package_serializer.data,
                 "bike_types": bike_type_serializer.data,
                 "bike_sizes": BikeSizeSerializer(
                     BikeSize.objects.all(), many=True
@@ -627,9 +494,12 @@ class BikeAvailability(generics.ListAPIView):
                             date += datetime.timedelta(days=1)
                 else:
                     for rental in bike["rental"]:
+                        if rental["id"] == 102:
+                            print(bike_model["id"], rental)
                         start_date = datetime.datetime.fromisoformat(
                             rental["start_date"]
                         )
+                        start_date -= datetime.timedelta(days=2)
                         end_date = datetime.datetime.fromisoformat(rental["end_date"])
                         # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
                         end_date += datetime.timedelta(days=1)
@@ -656,6 +526,7 @@ class BikeAvailability(generics.ListAPIView):
                             date_str = date.strftime("%d.%m.%Y")
                             # if date_str not in bike["rental_dates"]:
                             #    bike["rental_dates"].append(date_str)
+
                             if date_str in unavailable:
 
                                 unavailable[date_str] = 1 + unavailable[date_str]

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -537,13 +537,17 @@ class RentalListView(generics.ListCreateAPIView):
                 date = start_date
                 while date <= end_date:
                     date_str = date.strftime("%d.%m.%Y")
-                    if date_str not in bike["rental_dates"]:
+                    if (
+                        date_str not in bike["rental_dates"]
+                        and date > timezone.now() - datetime.timedelta(days=10)
+                        and date <= end_date - datetime.timedelta(days=10)
+                    ):
                         bike["rental_dates"].append(date_str)
                     date += datetime.timedelta(days=1)
             del bike["rental"]
         unavailable_dates = {}
         for bikedata in bikerentalserializer.data:
-            unavailable_dates[bikedata["bike_id"]] = bikedata["rental_dates"]
+            unavailable_dates[bikedata["id"]] = bikedata["rental_dates"]
 
         for trailer in trailer_rental_serializer.data:
             trailer["rental_dates"] = []

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -283,6 +283,217 @@ class BikeStockDetailView(generics.RetrieveUpdateDestroyAPIView):
         return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
 
 
+class MainBikeList(generics.ListAPIView):
+    serializer_class = MainBikeListSchemaSerializer
+    queryset = Bike.objects.none()
+
+    authentication_classes = [
+        SessionAuthentication,
+        BasicAuthentication,
+        JWTAuthentication,
+        CustomJWTAuthentication,
+    ]
+
+    permission_classes = [IsAuthenticated, HasGroupPermission]
+    required_groups = {
+        "GET": ["bicycle_group", "user_group"],
+        "LIST": ["bicycle_group", "user_group"],
+    }
+
+    def list(self, request, *args, **kwargs):
+        today = datetime.date.today()
+        available_from = today + datetime.timedelta(days=7)
+        available_to = today + datetime.timedelta(days=183)
+        fin_holidays = holidays.FI()
+
+        bike_serializer = BikeSerializer(Bike.objects.all(), many=True)
+        bike_type_serializer = BikeTypeSerializer(BikeType.objects.all(), many=True)
+        bike_package_serializer = BikePackageSerializer(
+            BikePackage.objects.all(), many=True
+        )
+        trailer_serializer = BikeTrailerMainSerializer(
+            BikeTrailerModel.objects.all(), many=True
+        )
+
+        for index, bike_model in enumerate(bike_serializer.data):
+            package_only_count = 0
+            unavailable = {}
+            package_only_unavailable = {}
+            for bike in bike_model["stock"]:
+                bike["rental_dates"] = []
+                if bike["package_only"] is True:
+                    package_only_count += 1
+                    for rental in bike["rental"]:
+                        start_date = datetime.datetime.fromisoformat(
+                            rental["start_date"]
+                        )
+                        end_date = datetime.datetime.fromisoformat(rental["end_date"])
+                        # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
+                        end_date += datetime.timedelta(days=1)
+                        while end_date.weekday() >= 5 or end_date in fin_holidays:
+                            end_date += datetime.timedelta(days=1)
+                        second_day = end_date + datetime.timedelta(days=1)
+                        if second_day.weekday() >= 5 or second_day in fin_holidays:
+                            while (
+                                second_day.weekday() >= 5 or second_day in fin_holidays
+                            ):
+                                end_date += datetime.timedelta(days=1)
+                                second_day += datetime.timedelta(days=1)
+                            end_date += datetime.timedelta(days=1)
+                        else:
+                            end_date += datetime.timedelta(days=1)
+                        date = start_date
+                        while date <= end_date:
+                            # consider filter range if provided
+                            current_date = (
+                                date.date()
+                                if isinstance(date, datetime.datetime)
+                                else date
+                            )
+                            date_str = date.strftime("%d.%m.%Y")
+                            if date_str in package_only_unavailable:
+                                package_only_unavailable[date_str] = (
+                                    1 + package_only_unavailable[date_str]
+                                )
+                            else:
+                                package_only_unavailable[date_str] = 1
+                            date += datetime.timedelta(days=1)
+                else:
+                    for rental in bike["rental"]:
+                        start_date = datetime.datetime.fromisoformat(
+                            rental["start_date"]
+                        )
+                        end_date = datetime.datetime.fromisoformat(rental["end_date"])
+                        # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
+                        end_date += datetime.timedelta(days=1)
+                        while end_date.weekday() >= 5 or end_date in fin_holidays:
+                            end_date += datetime.timedelta(days=1)
+                        second_day = end_date + datetime.timedelta(days=1)
+                        if second_day.weekday() >= 5 or second_day in fin_holidays:
+                            while (
+                                second_day.weekday() >= 5 or second_day in fin_holidays
+                            ):
+                                end_date += datetime.timedelta(days=1)
+                                second_day += datetime.timedelta(days=1)
+                            end_date += datetime.timedelta(days=1)
+                        else:
+                            end_date += datetime.timedelta(days=1)
+                        date = start_date
+                        while date <= end_date:
+                            # consider filter range if provided
+                            current_date = (
+                                date.date()
+                                if isinstance(date, datetime.datetime)
+                                else date
+                            )
+                            date_str = date.strftime("%d.%m.%Y")
+                            # if date_str not in bike["rental_dates"]:
+                            #    bike["rental_dates"].append(date_str)
+                            if date_str in unavailable:
+
+                                unavailable[date_str] = 1 + unavailable[date_str]
+                            else:
+                                unavailable[date_str] = 1
+                            date += datetime.timedelta(days=1)
+
+                del bike["rental"]
+
+            bike_serializer.data[index]["unavailable"] = unavailable
+            bike_serializer.data[index]["package_only_count"] = package_only_count
+            bike_serializer.data[index][
+                "package_only_unavailable"
+            ] = package_only_unavailable
+            # del bike_serializer.data[index]["stock"]
+
+        for index, package in enumerate(bike_package_serializer.data):
+            serializer_package = bike_package_serializer.data[index]
+            serializer_package["type"] = "Paketti"
+            serializer_package["unavailable"] = {}
+            serializer_package["brand"] = None
+            serializer_package["color"] = None
+            max_available = None
+            for bike in package["bikes"]:
+                bike_object = Bike.objects.get(id=bike["bike"])
+                if "size" in serializer_package:
+                    serializer_package["size"] = (
+                        f"{serializer_package['size']} & {bike_object.size.name}"
+                    )
+                else:
+                    serializer_package["size"] = bike_object.size.name
+                bike_object_serializer = BikeSerializer(bike_object)
+                if "picture" in serializer_package:
+                    serializer_package["picture"] = (
+                        f"{serializer_package['picture']}&{bike_object.picture.picture_address}"
+                    )
+                else:
+                    serializer_package["picture"] = (
+                        f"{bike_object.picture.picture_address}"
+                    )
+                if bike["amount"] == 0:
+                    bike_max_available = bike["amount"]
+                else:
+                    bike_max_available = math.floor(
+                        bike_object_serializer.data["max_available"] / bike["amount"]
+                    )
+                if max_available is None:
+                    max_available = bike_max_available
+                else:
+                    max_available = min(max_available, bike_max_available)
+            serializer_package["max_available"] = max_available
+
+        for index, trailer in enumerate(trailer_serializer.data):
+            unavailable = {}
+            for trailer in trailer["trailer"]:
+                for rental in trailer["trailer_rental"]:
+                    start_date = datetime.datetime.fromisoformat(rental["start_date"])
+                    end_date = datetime.datetime.fromisoformat(rental["end_date"])
+                    # We want to give the warehouse workers two business days to maintain the trailers, after the rental has ended
+                    end_date += datetime.timedelta(days=1)
+                    while end_date.weekday() >= 5 or end_date in fin_holidays:
+                        end_date += datetime.timedelta(days=1)
+                    second_day = end_date + datetime.timedelta(days=1)
+                    if second_day.weekday() >= 5 or second_day in fin_holidays:
+                        while second_day.weekday() >= 5 or second_day in fin_holidays:
+                            end_date += datetime.timedelta(days=1)
+                            second_day += datetime.timedelta(days=1)
+                        end_date += datetime.timedelta(days=1)
+                    else:
+                        end_date += datetime.timedelta(days=1)
+                    date = start_date
+                    while date <= end_date:
+                        # consider filter range if provided
+                        current_date = (
+                            date.date() if isinstance(date, datetime.datetime) else date
+                        )
+                        date_str = date.strftime("%d.%m.%Y")
+                        if date_str in unavailable:
+                            unavailable[date_str] = 1 + unavailable[date_str]
+                        else:
+                            unavailable[date_str] = 1
+                        date += datetime.timedelta(days=1)
+            trailer_serializer.data[index]["unavailable"] = unavailable
+            del trailer_serializer.data[index]["trailer"]
+
+        return Response(
+            {
+                "date_info": {
+                    "available_from": available_from,
+                    "available_to": available_to,
+                },
+                "bikes": bike_serializer.data,
+                "packages": bike_package_serializer.data,
+                "bike_types": bike_type_serializer.data,
+                "bike_sizes": BikeSizeSerializer(
+                    BikeSize.objects.all(), many=True
+                ).data,
+                "bike_brands": BikeBrandSerializer(
+                    BikeBrand.objects.all(), many=True
+                ).data,
+                "trailers": trailer_serializer.data,
+            }
+        )
+
+
 @extend_schema_view(
     get=extend_schema(
         parameters=[
@@ -303,7 +514,7 @@ class BikeStockDetailView(generics.RetrieveUpdateDestroyAPIView):
         ]
     )
 )
-class MainBikeList(generics.ListAPIView):
+class BikeAvailability(generics.ListAPIView):
     serializer_class = MainBikeListSchemaSerializer
     queryset = Bike.objects.none()
 
@@ -563,13 +774,8 @@ class MainBikeList(generics.ListAPIView):
 
         return Response(
             {
-                "date_info": {
-                    "available_from": available_from,
-                    "available_to": available_to,
-                },
                 "bikes": bike_serializer.data,
                 "packages": bike_package_serializer.data,
-                "trailers": trailer_serializer.data,
             }
         )
 

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -88,6 +88,25 @@ def resize_image(image, extension="JPEG"):
     return outcont
 
 
+def add_maintananse_dates(end_date):
+    fin_holidays = holidays.FI()
+    end_date = datetime.datetime.fromisoformat(end_date)
+    # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
+    end_date += datetime.timedelta(days=1)
+    while end_date.weekday() >= 5 or end_date in fin_holidays:
+        end_date += datetime.timedelta(days=1)
+    second_day = end_date + datetime.timedelta(days=1)
+    if second_day.weekday() >= 5 or second_day in fin_holidays:
+        while second_day.weekday() >= 5 or second_day in fin_holidays:
+            end_date += datetime.timedelta(days=1)
+            second_day += datetime.timedelta(days=1)
+        end_date += datetime.timedelta(days=1)
+    else:
+        end_date += datetime.timedelta(days=1)
+
+    return end_date
+
+
 class BikeStockFilter(filters.FilterSet):
     search = filters.CharFilter(method="search_filter", label="Search")
 
@@ -317,23 +336,9 @@ class MainBikeList(generics.ListAPIView):
                     start_date = datetime.datetime.fromisoformat(rental["start_date"])
                     end_date = datetime.datetime.fromisoformat(rental["end_date"])
                     # We want to give the warehouse workers two business days to maintain the trailers, after the rental has ended
-                    end_date += datetime.timedelta(days=1)
-                    while end_date.weekday() >= 5 or end_date in fin_holidays:
-                        end_date += datetime.timedelta(days=1)
-                    second_day = end_date + datetime.timedelta(days=1)
-                    if second_day.weekday() >= 5 or second_day in fin_holidays:
-                        while second_day.weekday() >= 5 or second_day in fin_holidays:
-                            end_date += datetime.timedelta(days=1)
-                            second_day += datetime.timedelta(days=1)
-                        end_date += datetime.timedelta(days=1)
-                    else:
-                        end_date += datetime.timedelta(days=1)
+                    end_date = add_maintananse_dates(end_date.isoformat())
                     date = start_date
                     while date <= end_date:
-                        # consider filter range if provided
-                        current_date = (
-                            date.date() if isinstance(date, datetime.datetime) else date
-                        )
                         date_str = date.strftime("%d.%m.%Y")
                         if date_str in unavailable:
                             unavailable[date_str] = 1 + unavailable[date_str]
@@ -367,14 +372,14 @@ class MainBikeList(generics.ListAPIView):
             OpenApiParameter(
                 name="start_date",
                 description="Filter: start date (DD.MM.YYYY).",
-                required=False,
+                required=True,
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
             ),
             OpenApiParameter(
                 name="end_date",
                 description="Filter: end date (DD.MM.YYYY).",
-                required=False,
+                required=True,
                 type=OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
             ),
@@ -412,7 +417,7 @@ class BikeAvailability(generics.ListAPIView):
         end_param = request.query_params.get("end_date")
         filter_start = None
         filter_end = None
-        print(start_param, end_param)
+
         if start_param:
             try:
                 filter_start = datetime.datetime.strptime(
@@ -443,6 +448,11 @@ class BikeAvailability(generics.ListAPIView):
         trailer_serializer = BikeTrailerMainSerializer(
             BikeTrailerModel.objects.all(), many=True
         )
+
+        maintananse_start_date = datetime.datetime.fromisoformat(
+            filter_start.isoformat()
+        )
+        maintananse_end_date = add_maintananse_dates(filter_end.isoformat())
         for index, bike_model in enumerate(bike_serializer.data):
             package_only_count = 0
             unavailable = {}
@@ -458,21 +468,8 @@ class BikeAvailability(generics.ListAPIView):
                         start_date = datetime.datetime.fromisoformat(
                             rental["start_date"]
                         )
-                        end_date = datetime.datetime.fromisoformat(rental["end_date"])
-                        # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
-                        end_date += datetime.timedelta(days=1)
-                        while end_date.weekday() >= 5 or end_date in fin_holidays:
-                            end_date += datetime.timedelta(days=1)
-                        second_day = end_date + datetime.timedelta(days=1)
-                        if second_day.weekday() >= 5 or second_day in fin_holidays:
-                            while (
-                                second_day.weekday() >= 5 or second_day in fin_holidays
-                            ):
-                                end_date += datetime.timedelta(days=1)
-                                second_day += datetime.timedelta(days=1)
-                            end_date += datetime.timedelta(days=1)
-                        else:
-                            end_date += datetime.timedelta(days=1)
+                        start_date -= datetime.timedelta(days=2)
+                        end_date = add_maintananse_dates(rental["end_date"])
                         date = start_date
                         while date <= end_date:
                             # consider filter range if provided
@@ -494,30 +491,13 @@ class BikeAvailability(generics.ListAPIView):
                             date += datetime.timedelta(days=1)
                 else:
                     for rental in bike["rental"]:
-                        if rental["id"] == 102:
-                            print(bike_model["id"], rental)
                         start_date = datetime.datetime.fromisoformat(
                             rental["start_date"]
                         )
                         start_date -= datetime.timedelta(days=2)
-                        end_date = datetime.datetime.fromisoformat(rental["end_date"])
-                        # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
-                        end_date += datetime.timedelta(days=1)
-                        while start_date.weekday() >= 5 or start_date in fin_holidays:
-                            start_date -= datetime.timedelta(days=1)
-                        while end_date.weekday() >= 5 or end_date in fin_holidays:
-                            end_date += datetime.timedelta(days=1)
-                        second_day = end_date + datetime.timedelta(days=1)
-                        if second_day.weekday() >= 5 or second_day in fin_holidays:
-                            while (
-                                second_day.weekday() >= 5 or second_day in fin_holidays
-                            ):
-                                end_date += datetime.timedelta(days=1)
-                                second_day += datetime.timedelta(days=1)
-                            end_date += datetime.timedelta(days=1)
-                        else:
-                            end_date += datetime.timedelta(days=1)
+                        end_date = add_maintananse_dates(rental["end_date"])
                         date = start_date
+
                         while date <= end_date:
                             # consider filter range if provided
                             current_date = (
@@ -526,8 +506,6 @@ class BikeAvailability(generics.ListAPIView):
                                 else date
                             )
                             date_str = date.strftime("%d.%m.%Y")
-                            # if date_str not in bike["rental_dates"]:
-                            #    bike["rental_dates"].append(date_str)
 
                             if date_str in unavailable:
 
@@ -537,31 +515,26 @@ class BikeAvailability(generics.ListAPIView):
                             date += datetime.timedelta(days=1)
 
                             if (
-                                (filter_start is None or current_date >= filter_start)
-                                and (filter_end is None or current_date <= filter_end)
+                                (
+                                    filter_start is None
+                                    or current_date >= maintananse_start_date.date()
+                                )
+                                and (
+                                    filter_end is None
+                                    or current_date <= maintananse_end_date.date()
+                                )
                                 and date_str in unavailable
                             ):
                                 bike_unavailable = True
-                                """ if bike_model["id"] == 2:
-                                    print(
-                                        "date_str: ",
-                                        date_str,
-                                        "current_date: ",
-                                        current_date,
-                                        "filter_start: ",
-                                        filter_start,
-                                        "filter_end: ",
-                                        filter_end,
-                                    ) """
+
                 del bike["rental"]
-                # if bike_model["id"] == 2:
-                #    print("bike id: ", bike["id"], ", unavailable: ", unavailable)
                 bike["unavailable"] = bike_unavailable
                 if bike_unavailable:
                     unavailable_amount += 1
 
                 date = filter_start
-                while date <= filter_end:
+
+                while date <= maintananse_end_date.date():
                     date_str = date.strftime("%d.%m.%Y")
                     unavailable[date_str] = unavailable_amount
                     date += datetime.timedelta(days=1)
@@ -571,7 +544,7 @@ class BikeAvailability(generics.ListAPIView):
             bike_serializer.data[index][
                 "package_only_unavailable"
             ] = package_only_unavailable
-            # del bike_serializer.data[index]["stock"]
+            del bike_serializer.data[index]["stock"]
 
         for index, package in enumerate(bike_package_serializer.data):
             serializer_package = bike_package_serializer.data[index]
@@ -614,19 +587,7 @@ class BikeAvailability(generics.ListAPIView):
             for trailer in trailer["trailer"]:
                 for rental in trailer["trailer_rental"]:
                     start_date = datetime.datetime.fromisoformat(rental["start_date"])
-                    end_date = datetime.datetime.fromisoformat(rental["end_date"])
-                    # We want to give the warehouse workers two business days to maintain the trailers, after the rental has ended
-                    end_date += datetime.timedelta(days=1)
-                    while end_date.weekday() >= 5 or end_date in fin_holidays:
-                        end_date += datetime.timedelta(days=1)
-                    second_day = end_date + datetime.timedelta(days=1)
-                    if second_day.weekday() >= 5 or second_day in fin_holidays:
-                        while second_day.weekday() >= 5 or second_day in fin_holidays:
-                            end_date += datetime.timedelta(days=1)
-                            second_day += datetime.timedelta(days=1)
-                        end_date += datetime.timedelta(days=1)
-                    else:
-                        end_date += datetime.timedelta(days=1)
+                    end_date = add_maintananse_dates(rental["end_date"])
                     date = start_date
                     while date <= end_date:
                         # consider filter range if provided
@@ -715,27 +676,15 @@ class RentalListView(generics.ListCreateAPIView):
             BikeTrailer.objects.all(), many=True
         )
         end_date_with_maintenance = request_end_date
+        _, end_date_with_maintenance = add_maintananse_dates(
+            None, end_date_with_maintenance.isoformat()
+        )
+
         for bike in bikerentalserializer.data:
             bike["rental_dates"] = []
             for rental in bike["rental"]:
                 start_date = datetime.datetime.fromisoformat(rental["start_date"])
-                end_date = datetime.datetime.fromisoformat(rental["end_date"])
-                end_date += datetime.timedelta(days=1)
-                end_date_with_maintenance += datetime.timedelta(days=1)
-                while end_date.weekday() >= 5 or end_date in fin_holidays:
-                    end_date += datetime.timedelta(days=1)
-                    end_date_with_maintenance += datetime.timedelta(days=1)
-                second_day = end_date + datetime.timedelta(days=1)
-                if second_day.weekday() >= 5 or second_day in fin_holidays:
-                    while second_day.weekday() >= 5 or second_day in fin_holidays:
-                        end_date += datetime.timedelta(days=1)
-                        end_date_with_maintenance += datetime.timedelta(days=1)
-                        second_day += datetime.timedelta(days=1)
-                    end_date += datetime.timedelta(days=1)
-                    end_date_with_maintenance += datetime.timedelta(days=1)
-                else:
-                    end_date += datetime.timedelta(days=1)
-                    end_date_with_maintenance += datetime.timedelta(days=1)
+                end_date = add_maintananse_dates(rental["end_date"])
                 date = start_date
                 while date <= end_date:
                     date_str = date.strftime("%d.%m.%Y")
@@ -752,18 +701,7 @@ class RentalListView(generics.ListCreateAPIView):
             trailer["rental_dates"] = []
             for rental in trailer["trailer_rental"]:
                 start_date = datetime.datetime.fromisoformat(rental["start_date"])
-                end_date = datetime.datetime.fromisoformat(rental["end_date"])
-                end_date += datetime.timedelta(days=1)
-                while end_date.weekday() >= 5 or end_date in fin_holidays:
-                    end_date += datetime.timedelta(days=1)
-                second_day = end_date + datetime.timedelta(days=1)
-                if second_day.weekday() >= 5 or second_day in fin_holidays:
-                    while second_day.weekday() >= 5 or second_day in fin_holidays:
-                        end_date += datetime.timedelta(days=1)
-                        second_day += datetime.timedelta(days=1)
-                    end_date += datetime.timedelta(days=1)
-                else:
-                    end_date += datetime.timedelta(days=1)
+                end_date = add_maintananse_dates(rental["end_date"])
                 date = start_date
                 while date <= end_date:
                     date_str = date.strftime("%d.%m.%Y")

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -543,7 +543,7 @@ class RentalListView(generics.ListCreateAPIView):
             del bike["rental"]
         unavailable_dates = {}
         for bikedata in bikerentalserializer.data:
-            unavailable_dates[bikedata["id"]] = bikedata["rental_dates"]
+            unavailable_dates[bikedata["bike_id"]] = bikedata["rental_dates"]
 
         for trailer in trailer_rental_serializer.data:
             trailer["rental_dates"] = []

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -503,6 +503,8 @@ class BikeAvailability(generics.ListAPIView):
                         end_date = datetime.datetime.fromisoformat(rental["end_date"])
                         # We want to give the warehouse workers two business days to maintain the bikes, after the rental has ended
                         end_date += datetime.timedelta(days=1)
+                        while start_date.weekday() >= 5 or start_date in fin_holidays:
+                            start_date -= datetime.timedelta(days=1)
                         while end_date.weekday() >= 5 or end_date in fin_holidays:
                             end_date += datetime.timedelta(days=1)
                         second_day = end_date + datetime.timedelta(days=1)

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -9,7 +9,12 @@ import holidays
 from django.core.files.base import ContentFile
 from django.utils import timezone
 from django_filters import rest_framework as filters
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    extend_schema,
+    extend_schema_view,
+    OpenApiParameter,
+    OpenApiTypes,
+)
 from django.db.models import Q
 from django.conf import settings
 from django.core.mail import send_mail
@@ -58,6 +63,7 @@ from bikes.serializers import (
     BikeStockDetailSerializer,
     BikeStockListSerializer,
     BikeStockSchemaCreateUpdateSerializer,
+    BikeStockSerializer,
     BikeTrailerAvailabilityListSerializer,
     BikeTrailerMainSerializer,
     BikeTrailerModelSerializer,
@@ -277,6 +283,26 @@ class BikeStockDetailView(generics.RetrieveUpdateDestroyAPIView):
         return Response(serializer.data, status=status.HTTP_202_ACCEPTED)
 
 
+@extend_schema_view(
+    get=extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="start_date",
+                description="Filter: start date (DD.MM.YYYY).",
+                required=False,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="end_date",
+                description="Filter: end date (DD.MM.YYYY).",
+                required=False,
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+            ),
+        ]
+    )
+)
 class MainBikeList(generics.ListAPIView):
     serializer_class = MainBikeListSchemaSerializer
     queryset = Bike.objects.none()
@@ -300,6 +326,36 @@ class MainBikeList(generics.ListAPIView):
         available_to = today + datetime.timedelta(days=183)
         fin_holidays = holidays.FI()
 
+        # Optional filters: allow callers to pass `start_date` and `end_date`
+        # as DD.MM.YYYY dates. When provided, the
+        # unavailable date maps are limited to this range and the
+        # `date_info` returned reflects these values.
+        start_param = request.query_params.get("start_date")
+        end_param = request.query_params.get("end_date")
+        filter_start = None
+        filter_end = None
+        if start_param:
+            try:
+                filter_start = datetime.date.fromisoformat(start_param)
+            except Exception:
+                try:
+                    filter_start = datetime.datetime.fromisoformat(start_param).date()
+                except Exception:
+                    filter_start = None
+        if end_param:
+            try:
+                filter_end = datetime.date.fromisoformat(end_param)
+            except Exception:
+                try:
+                    filter_end = datetime.datetime.fromisoformat(end_param).date()
+                except Exception:
+                    filter_end = None
+
+        if filter_start:
+            available_from = filter_start
+        if filter_end:
+            available_to = filter_end
+
         bike_serializer = BikeSerializer(Bike.objects.all(), many=True)
         bike_package_serializer = BikePackageSerializer(
             BikePackage.objects.all(), many=True
@@ -307,11 +363,16 @@ class MainBikeList(generics.ListAPIView):
         trailer_serializer = BikeTrailerMainSerializer(
             BikeTrailerModel.objects.all(), many=True
         )
-        for index, bike in enumerate(bike_serializer.data):
+        for index, bike_model in enumerate(bike_serializer.data):
             package_only_count = 0
             unavailable = {}
             package_only_unavailable = {}
-            for bike in bike["stock"]:
+            unavailable_amount = 0
+            for bike in bike_model["stock"]:
+                bike_unavailable = False
+                bike_unavailable_amount = 0
+
+                bike["rental_dates"] = []
                 if bike["package_only"] is True:
                     package_only_count += 1
                     for rental in bike["rental"]:
@@ -335,13 +396,22 @@ class MainBikeList(generics.ListAPIView):
                             end_date += datetime.timedelta(days=1)
                         date = start_date
                         while date <= end_date:
-                            date_str = date.strftime("%d.%m.%Y")
-                            if date_str in package_only_unavailable:
-                                package_only_unavailable[date_str] = (
-                                    1 + package_only_unavailable[date_str]
-                                )
-                            else:
-                                package_only_unavailable[date_str] = 1
+                            # consider filter range if provided
+                            current_date = (
+                                date.date()
+                                if isinstance(date, datetime.datetime)
+                                else date
+                            )
+                            if (
+                                filter_start is None or current_date >= filter_start
+                            ) and (filter_end is None or current_date <= filter_end):
+                                date_str = date.strftime("%d.%m.%Y")
+                                if date_str in package_only_unavailable:
+                                    package_only_unavailable[date_str] = (
+                                        1 + package_only_unavailable[date_str]
+                                    )
+                                else:
+                                    package_only_unavailable[date_str] = 1
                             date += datetime.timedelta(days=1)
                 else:
                     for rental in bike["rental"]:
@@ -365,18 +435,37 @@ class MainBikeList(generics.ListAPIView):
                             end_date += datetime.timedelta(days=1)
                         date = start_date
                         while date <= end_date:
-                            date_str = date.strftime("%d.%m.%Y")
-                            if date_str in unavailable:
-                                unavailable[date_str] = 1 + unavailable[date_str]
-                            else:
-                                unavailable[date_str] = 1
+                            # consider filter range if provided
+                            current_date = (
+                                date.date()
+                                if isinstance(date, datetime.datetime)
+                                else date
+                            )
+                            if (
+                                filter_start is None or current_date >= filter_start
+                            ) and (filter_end is None or current_date <= filter_end):
+                                date_str = date.strftime("%d.%m.%Y")
+                                # if date_str not in bike["rental_dates"]:
+                                #    bike["rental_dates"].append(date_str)
+                                if date_str in unavailable:
+                                    bike_unavailable_amount += 1
+                                    unavailable[date_str] = 1 + unavailable[date_str]
+                                else:
+                                    unavailable[date_str] = 1
                             date += datetime.timedelta(days=1)
+                del bike["rental"]
+                # if bike_model["id"] == 2:
+                #    print("bike id: ", bike["id"], ", unavailable: ", unavailable)
+                bike["unavailable"] = bike_unavailable_amount
+                if bike_unavailable:
+                    unavailable_amount += 1
             bike_serializer.data[index]["unavailable"] = unavailable
+            bike_serializer.data[index]["bike_unavailable"] = bike_unavailable
             bike_serializer.data[index]["package_only_count"] = package_only_count
             bike_serializer.data[index][
                 "package_only_unavailable"
             ] = package_only_unavailable
-            del bike_serializer.data[index]["stock"]
+            # del bike_serializer.data[index]["stock"]
 
         for index, package in enumerate(bike_package_serializer.data):
             serializer_package = bike_package_serializer.data[index]
@@ -434,11 +523,18 @@ class MainBikeList(generics.ListAPIView):
                         end_date += datetime.timedelta(days=1)
                     date = start_date
                     while date <= end_date:
-                        date_str = date.strftime("%d.%m.%Y")
-                        if date_str in unavailable:
-                            unavailable[date_str] = 1 + unavailable[date_str]
-                        else:
-                            unavailable[date_str] = 1
+                        # consider filter range if provided
+                        current_date = (
+                            date.date() if isinstance(date, datetime.datetime) else date
+                        )
+                        if (filter_start is None or current_date >= filter_start) and (
+                            filter_end is None or current_date <= filter_end
+                        ):
+                            date_str = date.strftime("%d.%m.%Y")
+                            if date_str in unavailable:
+                                unavailable[date_str] = 1 + unavailable[date_str]
+                            else:
+                                unavailable[date_str] = 1
                         date += datetime.timedelta(days=1)
             trailer_serializer.data[index]["unavailable"] = unavailable
             del trailer_serializer.data[index]["trailer"]
@@ -512,31 +608,33 @@ class RentalListView(generics.ListCreateAPIView):
             return Response(postserializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         bikerentalserializer = BikeAvailabilityListSerializer(
-            BikeStock.objects.filter(
-                bike_id__in=list(request.data["bike_stock"].keys())
-            ),
-            many=True,
+            BikeStock.objects.all(), many=True
         )
         trailer_rental_serializer = BikeTrailerAvailabilityListSerializer(
             BikeTrailer.objects.all(), many=True
         )
-
+        end_date_with_maintenance = request_end_date
         for bike in bikerentalserializer.data:
             bike["rental_dates"] = []
             for rental in bike["rental"]:
                 start_date = datetime.datetime.fromisoformat(rental["start_date"])
                 end_date = datetime.datetime.fromisoformat(rental["end_date"])
                 end_date += datetime.timedelta(days=1)
+                end_date_with_maintenance += datetime.timedelta(days=1)
                 while end_date.weekday() >= 5 or end_date in fin_holidays:
                     end_date += datetime.timedelta(days=1)
+                    end_date_with_maintenance += datetime.timedelta(days=1)
                 second_day = end_date + datetime.timedelta(days=1)
                 if second_day.weekday() >= 5 or second_day in fin_holidays:
                     while second_day.weekday() >= 5 or second_day in fin_holidays:
                         end_date += datetime.timedelta(days=1)
+                        end_date_with_maintenance += datetime.timedelta(days=1)
                         second_day += datetime.timedelta(days=1)
                     end_date += datetime.timedelta(days=1)
+                    end_date_with_maintenance += datetime.timedelta(days=1)
                 else:
                     end_date += datetime.timedelta(days=1)
+                    end_date_with_maintenance += datetime.timedelta(days=1)
                 date = start_date
                 while date <= end_date:
                     date_str = date.strftime("%d.%m.%Y")
@@ -596,7 +694,7 @@ class RentalListView(generics.ListCreateAPIView):
                     for bike_id in available_bikes:
                         check_date = request_start_date
                         if bike_id.id in unavailable_dates.keys():
-                            while check_date <= request_end_date:
+                            while check_date <= end_date_with_maintenance:
                                 if (
                                     check_date.strftime("%d.%m.%Y")
                                     in unavailable_dates[bike_id.id]
@@ -610,12 +708,12 @@ class RentalListView(generics.ListCreateAPIView):
 
             else:
                 available_bikes = BikeStock.objects.filter(
-                    bike=rental_item, package_only=False, state="AVAILABLE"
+                    package_only=False, state="AVAILABLE"
                 )
                 for bike_id in available_bikes:
                     check_date = request_start_date
                     if bike_id.id in unavailable_dates.keys():
-                        while check_date <= request_end_date:
+                        while check_date <= end_date_with_maintenance:
                             if (
                                 check_date.strftime("%d.%m.%Y")
                                 in unavailable_dates[bike_id.id]

--- a/bikes/views.py
+++ b/bikes/views.py
@@ -334,27 +334,29 @@ class MainBikeList(generics.ListAPIView):
         end_param = request.query_params.get("end_date")
         filter_start = None
         filter_end = None
+        print(start_param, end_param)
         if start_param:
             try:
-                filter_start = datetime.date.fromisoformat(start_param)
+                filter_start = datetime.datetime.strptime(
+                    start_param, "%d.%m.%Y"
+                ).date()
             except Exception:
                 try:
-                    filter_start = datetime.datetime.fromisoformat(start_param).date()
+                    filter_start = datetime.datetime.strptime(
+                        start_param, "%d.%m.%Y"
+                    ).date()
                 except Exception:
                     filter_start = None
         if end_param:
             try:
-                filter_end = datetime.date.fromisoformat(end_param)
+                filter_end = datetime.datetime.strptime(end_param, "%d.%m.%Y").date()
             except Exception:
                 try:
-                    filter_end = datetime.datetime.fromisoformat(end_param).date()
+                    filter_end = datetime.datetime.strptime(
+                        end_param, "%d.%m.%Y"
+                    ).date()
                 except Exception:
                     filter_end = None
-
-        if filter_start:
-            available_from = filter_start
-        if filter_end:
-            available_to = filter_end
 
         bike_serializer = BikeSerializer(Bike.objects.all(), many=True)
         bike_package_serializer = BikePackageSerializer(
@@ -370,7 +372,6 @@ class MainBikeList(generics.ListAPIView):
             unavailable_amount = 0
             for bike in bike_model["stock"]:
                 bike_unavailable = False
-                bike_unavailable_amount = 0
 
                 bike["rental_dates"] = []
                 if bike["package_only"] is True:
@@ -441,26 +442,47 @@ class MainBikeList(generics.ListAPIView):
                                 if isinstance(date, datetime.datetime)
                                 else date
                             )
-                            if (
-                                filter_start is None or current_date >= filter_start
-                            ) and (filter_end is None or current_date <= filter_end):
-                                date_str = date.strftime("%d.%m.%Y")
-                                # if date_str not in bike["rental_dates"]:
-                                #    bike["rental_dates"].append(date_str)
-                                if date_str in unavailable:
-                                    bike_unavailable_amount += 1
-                                    unavailable[date_str] = 1 + unavailable[date_str]
-                                else:
-                                    unavailable[date_str] = 1
+                            date_str = date.strftime("%d.%m.%Y")
+                            # if date_str not in bike["rental_dates"]:
+                            #    bike["rental_dates"].append(date_str)
+                            if date_str in unavailable:
+
+                                unavailable[date_str] = 1 + unavailable[date_str]
+                            else:
+                                unavailable[date_str] = 1
                             date += datetime.timedelta(days=1)
+
+                            if (
+                                (filter_start is None or current_date >= filter_start)
+                                and (filter_end is None or current_date <= filter_end)
+                                and date_str in unavailable
+                            ):
+                                bike_unavailable = True
+                                """ if bike_model["id"] == 2:
+                                    print(
+                                        "date_str: ",
+                                        date_str,
+                                        "current_date: ",
+                                        current_date,
+                                        "filter_start: ",
+                                        filter_start,
+                                        "filter_end: ",
+                                        filter_end,
+                                    ) """
                 del bike["rental"]
                 # if bike_model["id"] == 2:
                 #    print("bike id: ", bike["id"], ", unavailable: ", unavailable)
-                bike["unavailable"] = bike_unavailable_amount
+                bike["unavailable"] = bike_unavailable
                 if bike_unavailable:
                     unavailable_amount += 1
+
+                date = filter_start
+                while date <= filter_end:
+                    date_str = date.strftime("%d.%m.%Y")
+                    unavailable[date_str] = unavailable_amount
+                    date += datetime.timedelta(days=1)
             bike_serializer.data[index]["unavailable"] = unavailable
-            bike_serializer.data[index]["bike_unavailable"] = bike_unavailable
+            bike_serializer.data[index]["bike_unavailable"] = unavailable_amount
             bike_serializer.data[index]["package_only_count"] = package_only_count
             bike_serializer.data[index][
                 "package_only_unavailable"
@@ -708,7 +730,7 @@ class RentalListView(generics.ListCreateAPIView):
 
             else:
                 available_bikes = BikeStock.objects.filter(
-                    package_only=False, state="AVAILABLE"
+                    bike=rental_item, package_only=False, state="AVAILABLE"
                 )
                 for bike_id in available_bikes:
                     check_date = request_start_date


### PR DESCRIPTION
**Description**

fixed a bug that showed bikes that are available only part of the ordering time and so shows customers more bikes available than there actually are

there is a new endpoint that takes in order start and end time and checks if any bikes are available for the whole order time and only shows those bikes